### PR TITLE
name_admin_notify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "freeday-api",
-	"version": "1.2.3",
+	"version": "1.3.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "freeday-api",
-			"version": "1.2.3",
+			"version": "1.3.4",
 			"dependencies": {
 				"@google-cloud/dialogflow": "^5.1.0",
 				"@slack/bolt": "^3.12.0",

--- a/src/api/controllers/user.js
+++ b/src/api/controllers/user.js
@@ -156,6 +156,14 @@ const User = {
         if (controlUser) {
             throw new ConflictError(`Username ${username} already exists`);
         }
+    },
+
+    async findUserById(id) {
+        validateParamUuid(id);
+        const user = await Models.User.findOne({
+            _id: id
+        }).exec();
+        return user.toJSON();
     }
 
 };

--- a/src/bot/lang/en.json
+++ b/src/bot/lang/en.json
@@ -90,7 +90,7 @@
 		"user_create": "Your dayoff has been created",
 		"user_edit": "Your dayoff has been edited",
 		"user_delete": "Your dayoff has been deleted",
-		"action": "Your dayoff status has changed"
+		"action": "Your dayoff status has been changed by"
 	},
 	"errors": {
 		"no_work_days": "No work days in dayoff",

--- a/src/bot/lang/fr.json
+++ b/src/bot/lang/fr.json
@@ -90,7 +90,7 @@
 		"user_create": "Votre absence a été ajoutée",
 		"user_edit": "Votre absence a été modifiée",
 		"user_delete": "Votre absence a été supprimée",
-		"action": "Le statut de votre absence a changé"
+		"action": "Le statut de votre absence a été changée par %s"
 	},
 	"errors": {
 		"no_work_days": "Aucun jour ouvré dans cette absence",

--- a/src/bot/utils/notify.js
+++ b/src/bot/utils/notify.js
@@ -86,14 +86,14 @@ const Notify = {
     },
 
     // envoie notification à utilisateur après action sur absence
-    async statusChange(userId, dayoff) {
+    async statusChange(userId, dayoff, userAdmin) {
         Log.info(`Sending status change to channel ${userId} for dayoff ${dayoff.id}`);
         // récupère une fonction permettant d'obtenir le texte dans la langue de l'utilisateur
         const getText = await LanguageService.getUserLocaleAccessor(userId);
         let color = 'warning';
         if (dayoff.confirmed) { color = 'good'; }
         if (dayoff.canceled) { color = 'danger'; }
-        const title = getText('notifications.action');
+        const title = getText('notifications.action', userAdmin.username);
         const dayoffAttachment = Attachments.dayoff({
             dayoff,
             withTitle: title,


### PR DESCRIPTION
issue #16 
recuperer l'id de l'admin dans la requete du changement de statut du controleur dayoff 
fonction chercher le nom d'utilisateur a partir de l'id 
affichage dans la notif
